### PR TITLE
Fix gtk+ error messages when swap is disabled

### DIFF
--- a/src/display_sysinfo.rs
+++ b/src/display_sysinfo.rs
@@ -193,7 +193,12 @@ impl DisplaySysInfo {
         };
 
         self.swap.set_text(Some(&disp));
-        self.swap.set_fraction(used as f64 / total as f64);
+        
+        let mut fraction = used as f64 / total as f64;
+        if fraction.is_nan() {
+        	fraction = 0 as f64;
+        }
+        self.swap.set_fraction(fraction);
 
         for (component, label) in sys.get_components_list().iter().zip(self.components.iter()) {
             label.set_text(&format!("{:.1} °C", component.temperature));


### PR DESCRIPTION
Before this commit, when swap is disabled, NaN is given to GtkProgressBar::set_fraction().
This leads to some warnings with Gtk+ 3.20:

`Gtk-WARNING **: Negative content width -2147483648 (allocation -2147483648, extents 0x0) while allocating gadget (node progress, owner GtkProgressBar)`

when sysinfo page is visible, this warning showed up too:

`Gtk-WARNING **: Drawing a gadget with negative dimensions. Did you forget to allocate a size? (node progress, owner GtkProgressBar)`

This commit removes these warnings.