### PR TITLE
fixed unwrap panic on new task

### DIFF
--- a/src/process_viewer.rs
+++ b/src/process_viewer.rs
@@ -480,8 +480,9 @@ fn build_ui(application: &gtk::Application) {
         // To make "run" and "cancel" button take all spaces.
         if let Some(run) = dialog.get_widget_for_response(gtk::ResponseType::Other(0)) {
             if let Some(parent) = run.get_parent() {
-                let parent = parent.downcast::<gtk::ButtonBox>().unwrap();
-                parent.set_property_layout_style(gtk::ButtonBoxStyle::Expand);
+                if let Ok(parent) = parent.downcast::<gtk::ButtonBox>() {
+                    parent.set_property_layout_style(gtk::ButtonBoxStyle::Expand);
+                }
             }
         }
         input.connect_changed(clone!(dialog => move |input| {

--- a/src/process_viewer.rs
+++ b/src/process_viewer.rs
@@ -480,8 +480,9 @@ fn build_ui(application: &gtk::Application) {
         // To make "run" and "cancel" button take all spaces.
         if let Some(run) = dialog.get_widget_for_response(gtk::ResponseType::Other(0)) {
             if let Some(parent) = run.get_parent() {
-                if let Ok(parent) = parent.downcast::<gtk::ButtonBox>() {
-                    parent.set_property_layout_style(gtk::ButtonBoxStyle::Expand);
+                match parent.downcast::<gtk::ButtonBox>() {
+                    Ok(parent) => parent.set_property_layout_style(gtk::ButtonBoxStyle::Expand),
+                    Err(_) => eprintln!("<Process_Viewer::build_ui> Failed to set layout style for new task button box..."),
                 }
             }
         }


### PR DESCRIPTION
On my local Fedora system I get following panic if try to open the new task dialog. Checking the value works fine. 

thread 'main' panicked at 'called `Result::unwrap()` on an `Err` value: Widget { inner: ObjectRef(Shared { inner: 0x55e0bf1b0930, borrowed: false }), type: GtkHeaderBar }', src/libcore/result.rs:1084:5

