### PR TITLE
Add SVG icon, appdata and desktop files

### DIFF
--- a/assets/process-viewer.appdata.xml
+++ b/assets/process-viewer.appdata.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="desktop-application">
+  <id>fr.guillaume_gomez.ProcessViewer</id>
+  <metadata_license>MIT</metadata_license>
+  <project_license>MIT</project_license>
+  <name>Process Viewer</name>
+  <summary>Process viewer GUI written in Rust</summary>
+  <description>
+    <p>
+      Process Viewer provides current status of your processes
+      (cpu and memory usage) and your system (usage of every core
+      and of your RAM, and the temperature of your components if
+      this information is available).
+    </p>
+  </description>
+  <developer_name>Guillaume Gomez</developer_name>
+  <url type="homepage">https://github.com/GuillaumeGomez/process-viewer/</url>
+  <url type="bugtracker">https://github.com/GuillaumeGomez/process-viewer/issues</url>
+  <categories>
+    <category>System</category>
+  </categories>
+  <launchable type="desktop-id">process-viewer.desktop</launchable>
+  <provides>
+    <binary>process_viewer</binary>
+  </provides>
+</component>

--- a/assets/process-viewer.desktop
+++ b/assets/process-viewer.desktop
@@ -1,0 +1,17 @@
+[Desktop Entry]
+Type=Application
+Version=1.0
+Name=Process Viewer
+Name[en]=Process Viewer
+GenericName=Process Viewer
+GenericName[en]=Process Viewer
+GenericName[de]=Prozessbetrachter
+Comment=View current status of processes and system
+Comment[en]=View current status of processes and system
+Comment[de]=Betrachten des Prozess- und Systemstatus
+Icon=process-viewer
+Exec=process_viewer
+Terminal=false
+StartupNotify=false
+Categories=System;
+Keywords=system;process;

--- a/assets/process-viewer.svg
+++ b/assets/process-viewer.svg
@@ -1,0 +1,121 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="51.018002mm"
+   height="51.018002mm"
+   viewBox="0 0 51.018002 51.018002"
+   version="1.1"
+   id="svg8"
+   sodipodi:docname="icon.svg"
+   inkscape:version="0.92.3 (2405546, 2018-03-11)">
+  <defs
+     id="defs2" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="0.98994949"
+     inkscape:cx="71.088892"
+     inkscape:cy="16.165505"
+     inkscape:document-units="mm"
+     inkscape:current-layer="layer1"
+     showgrid="false"
+     fit-margin-top="0"
+     fit-margin-left="0"
+     fit-margin-right="0"
+     fit-margin-bottom="0"
+     inkscape:window-width="1920"
+     inkscape:window-height="1019"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1" />
+  <metadata
+     id="metadata5">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(-56.943,-72.621943)">
+    <rect
+       style="opacity:1;fill:#e1e4de;fill-opacity:1;stroke:none;stroke-width:1.01756513;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect4518"
+       width="50"
+       height="50"
+       x="57.452"
+       y="73.130943" />
+    <g
+       id="g4621"
+       transform="translate(0,1.7832248)">
+      <path
+         sodipodi:nodetypes="cc"
+         inkscape:connector-curvature="0"
+         id="path4524-5"
+         d="M 57.020837,108.68502 H 107.02082"
+         style="fill:none;stroke:#787878;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+      <path
+         sodipodi:nodetypes="cc"
+         inkscape:connector-curvature="0"
+         id="path4524-5-3"
+         d="M 57.020837,96.347706 H 107.02083"
+         style="fill:none;stroke:#787878;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+      <path
+         sodipodi:nodetypes="cc"
+         inkscape:connector-curvature="0"
+         id="path4524-5-3-5"
+         d="M 57.020837,84.010417 H 107.02083"
+         style="fill:none;stroke:#787878;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    </g>
+    <path
+       style="fill:none;stroke:#b43fff;stroke-width:3;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 57.545729,80.601918 13.18202,30.063492 21.306147,-14.97608 14.941524,7.40021"
+       id="path4526-3-6"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccc" />
+    <path
+       style="fill:none;stroke:#ff512a;stroke-width:3;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="M 57.754587,114.58754 70.159693,93.358951 89.575958,83.863526 107.17112,99.780286"
+       id="path4526-3"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccc" />
+    <path
+       style="fill:none;stroke:#0137ff;stroke-width:3;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="M 57.68777,107.41549 74.695407,94.492871 93.355721,115.80251 107.10796,109.04957"
+       id="path4526-3-6-7"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccc" />
+    <path
+       style="fill:none;stroke:#fd8b41;stroke-width:3;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 57.462947,104.70668 12.561669,12.2944 37.366474,-36.474371"
+       id="path4526"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccc" />
+    <rect
+       y="73.130943"
+       x="57.452"
+       height="50"
+       width="50"
+       id="rect4623"
+       style="opacity:1;fill:none;fill-opacity:1;stroke:#000000;stroke-width:1.01800001;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+  </g>
+</svg>


### PR DESCRIPTION
I created some metadata for the project. I simply dumped it into the assets directory, and added no meta-information to the project about how or where to install them. None the less they would be helpful for distributions (like Debian, for which I package the project) even if simply distributed with the source to crates.io.