### PR TITLE
Unlink python2 in travis during 'before_install' phase

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,7 @@ addons:
       - libmount-dev
 before_install:
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew unlink python@2; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install gtk+3 cairo atk; fi
 script:
   - rustc --version


### PR DESCRIPTION
Fix travis build by unlinking brew python2 in build for osx, which was causing travis to fail.