### PR TITLE
Draft: Update to gtk-rs 0.8

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,8 @@ readme = "README.md"
 keywords = ["GUI", "process", "viewer", "gtk"]
 
 [dependencies]
-gtk = { version = "0.7", package = "gtk4" }
+async-channel = { version = "2.2" }
+gtk = { version = "0.8", package = "gtk4" }
 sysinfo = "0.28.2"
 libc = "0.2"
 serde = "1.0"

--- a/src/display_sysinfo.rs
+++ b/src/display_sysinfo.rs
@@ -385,7 +385,7 @@ impl DisplaySysInfo {
     }
 }
 
-pub fn show_if_necessary<U: gtk::glib::IsA<gtk::CheckButton>, T: WidgetExt>(
+pub fn show_if_necessary<U: gtk::prelude::IsA<gtk::CheckButton>, T: WidgetExt>(
     check_box: &U,
     proc_horizontal_layout: &GraphWidget,
     non_graph_layout: &T,


### PR DESCRIPTION
I did the first few steps in porting to gtk-rs 0.8 (associated with GNOME 46).

A major change is that glib has [dropped](https://github.com/gtk-rs/gtk-rs-core/pull/1216) the MainContext channel and you're expected to use async channels instead. I did not implement that although I updated cargo to include the likely crate you'd want to use for it.